### PR TITLE
Improving handling of empty timestamps in the parser.

### DIFF
--- a/src/SrtParser/Parser.php
+++ b/src/SrtParser/Parser.php
@@ -50,7 +50,9 @@ class Parser
             //cleans out control characters, borrowed from https://stackoverflow.com/a/23066553
             $section = preg_replace('/[^\PC\s]/u', '', $section);
             if(trim($section) == '') continue;
-            $matches[] = preg_split('/(\r\n|\r|\n)/', $section, 2,PREG_SPLIT_NO_EMPTY);
+            $section = preg_split('/(\r\n|\r|\n)/', rtrim($section), 2,PREG_SPLIT_NO_EMPTY);
+            if (count($section) == 1) continue;
+            $matches[] = $section;
         }
         return $matches;
     }


### PR DESCRIPTION
Hey! Thank you for the library :)

We have applied it to our particular use case and it does pretty good job. The only problem we've discovered is that our subtitles (which are auto-generated by 3rd party vendor), sometimes could have a bit strange entries with just empty text, i.e. it would specify some timestamp but would not specify any text/wording for that time interval, just an empty line. Let me show an example:

```
1
00:00:00,000 --> 00:00:00,500


2
00:00:00,500 --> 00:00:05,600
I was asked to verify that I did
not file a Federal income tax
```

You see the section first section does not specify any text, just an empty line (an empty text, if you like). It was generating some PHP notices, so I opted to patch a bit the parser logic.